### PR TITLE
Updated `<line-style>` reference to link to `<line-style>` article

### DIFF
--- a/files/en-us/web/css/border/index.md
+++ b/files/en-us/web/css/border/index.md
@@ -50,7 +50,7 @@ The `border` property may be specified using one, two, or three of the values li
 
 - `<line-width>`
   - : Sets the thickness of the border. Defaults to `medium` if absent. See {{Cssxref("border-width")}}.
-- `<line-style>`
+- {{cssxref("&lt;line-style&gt;")}}
   - : Sets the style of the border. Defaults to `none` if absent. See {{Cssxref("border-style")}}.
 - {{cssxref("&lt;color&gt;")}}
   - : Sets the color of the border. Defaults to `currentcolor` if absent. See {{Cssxref("border-color")}}.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Copied the format used to link to `<color>` to also link to `<line-style>` to the [`<line-style>` article](https://developer.mozilla.org/en-US/docs/Web/CSS/line-style)

### Motivation
While reading [this section of the border article](https://developer.mozilla.org/en-US/docs/Web/CSS/border#values), I needed to refer to an article on `<line-style>` but I assumed MDN didn't have one because the text wasn't linked. After googling, I was led back to the [MDN article](https://developer.mozilla.org/en-US/docs/Web/CSS/line-style) on it. I am making this change so it's easier to jump to MDN's article
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
